### PR TITLE
feat: integrate TanStack Query with QueryClient, useQuery and useMuta…

### DIFF
--- a/InternArena/package-lock.json
+++ b/InternArena/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^7.3.1",
         "@tailwindcss/postcss": "^4.1.12",
         "@tailwindcss/vite": "^4.1.12",
+        "@tanstack/react-query": "^5.101.2",
         "motion": "^12.34.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -1970,6 +1971,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/InternArena/package.json
+++ b/InternArena/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^7.3.1",
     "@tailwindcss/postcss": "^4.1.12",
     "@tailwindcss/vite": "^4.1.12",
+    "@tanstack/react-query": "^5.101.2",
     "motion": "^12.34.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/InternArena/src/main.jsx
+++ b/InternArena/src/main.jsx
@@ -6,14 +6,19 @@ import { BrowserRouter } from "react-router-dom";
 import { CssBaseline } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 import { theme } from "./theme";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
     </ThemeProvider>
   </StrictMode>,
 )

--- a/InternArena/src/screens/LandingPage/components/RecentRankings.jsx
+++ b/InternArena/src/screens/LandingPage/components/RecentRankings.jsx
@@ -1,17 +1,36 @@
-import Ranking from "./Ranking"
+import { useQuery } from "@tanstack/react-query";
+import Ranking from "./Ranking";
+
+const fetchRankings = async () => {
+    const response = await fetch("http://localhost:8080/api/rankings");
+    if (!response.ok) throw new Error("Failed to fetch rankings");
+    return response.json();
+};
 
 function RecentRankings() {
-    return(
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ["rankings"],
+        queryFn: fetchRankings,
+    });
+
+    return (
         <div className="w-xs m-4 rounded-xl text-2xl text-white">
             <div className="m-4">
                 <p>Recent Rankings:</p>
-                {/*hacer fetch para obtener los rankings @backend*/}
-                <Ranking/>
-                <Ranking/>
-                <Ranking/>
+                {isLoading && <p className="text-sm">Loading...</p>}
+                {isError && <p className="text-sm">Could not load rankings.</p>}
+                {data?.map((ranking, index) => (
+                    <Ranking key={index} data={ranking} />
+                )) ?? (
+                    <>
+                        <Ranking/>
+                        <Ranking/>
+                        <Ranking/>
+                    </>
+                )}
             </div>
         </div>
-    )
+    );
 }
 
-export default RecentRankings
+export default RecentRankings;

--- a/InternArena/src/screens/MatchConfig/MatchConfig.jsx
+++ b/InternArena/src/screens/MatchConfig/MatchConfig.jsx
@@ -11,9 +11,27 @@ import Stack from "@mui/material/Stack";
 import Button from "@mui/material/Button";
 import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
+import { useMutation } from "@tanstack/react-query";
 
 function MatchConfig() {
     const navigate = useNavigate();
+    const createMatchMutation = useMutation({
+    mutationFn: async (payload) => {
+        const response = await fetch("http://localhost:8080/api/match", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        });
+        if (!response.ok) throw new Error("Failed to create match");
+        return response.json();
+    },
+    onSuccess: () => {
+        setToast({ open: true, severity: "success", message: "Match created successfully!" });
+    },
+    onError: () => {
+        setToast({ open: true, severity: "error", message: "Failed to create match." });
+    },
+});
     //Difficulty
     //Time
     //Prize
@@ -104,16 +122,12 @@ function MatchConfig() {
     };
 
     const handleCreateMatch = () => {
-        if (!validateForm()) {
-            setToast({ open: true, severity: "error", message: "Fill all required fields before creating the match." });
-            return;
-        }
-
-        const payload = buildPayloadForBackend();
-
-        // TODO: replace with your real backend call (fetch/axios)
-        console.log("CreateMatch payload:", payload);
-        setToast({ open: true, severity: "success", message: "Match payload ready to send." });
+    if (!validateForm()) {
+        setToast({ open: true, severity: "error", message: "Fill all required fields before creating the match." });
+        return;
+    }
+    const payload = buildPayloadForBackend();
+    createMatchMutation.mutate(payload);
     };
 
     const openDifficulty = () => {


### PR DESCRIPTION
Installed TanStack Query and set up QueryClient with QueryClientProvider wrapping the app in main.jsx. Migrated RecentRankings to useQuery for fetching rankings and MatchConfig to useMutation for creating a match, both with loading and error handling. No existing functionality was broken.